### PR TITLE
feat(): try to connect to database in bootstrap

### DIFF
--- a/lib/sequelize-core.module.ts
+++ b/lib/sequelize-core.module.ts
@@ -145,6 +145,9 @@ export class SequelizeCoreModule implements OnApplicationShutdown {
         connectionToken,
       );
       sequelize.addModels(models as any);
+
+      await sequelize.authenticate();
+
       if (typeof options.synchronize === 'undefined' || options.synchronize) {
         await sequelize.sync(options.sync);
       }

--- a/tests/e2e/sequelize-authenticate.spec.ts
+++ b/tests/e2e/sequelize-authenticate.spec.ts
@@ -1,0 +1,13 @@
+import { Test } from '@nestjs/testing';
+import { ApplicationAuthenticateModule } from '../src/app-authenticate.module';
+import { ConnectionRefusedError } from 'sequelize';
+
+describe('Sequelize (authenticate)', () => {
+  it(`should throw error`, async () => {
+    const module = Test.createTestingModule({
+      imports: [ApplicationAuthenticateModule],
+    });
+
+    await expect(module.compile()).rejects.toThrow(ConnectionRefusedError);
+  });
+});

--- a/tests/src/app-authenticate.module.ts
+++ b/tests/src/app-authenticate.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { SequelizeModule } from '../../lib';
+
+@Module({
+  imports: [
+    SequelizeModule.forRoot({
+      database: 'test',
+      dialect: 'postgres',
+      logging: false,
+      username: 'root',
+      password: 'root',
+      host: '0.0.0.0',
+      port: 3307, // incorrect port to force an connection error
+      synchronize: false, // must be false because sync try to connect
+      autoLoadModels: true,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    }),
+  ],
+})
+export class ApplicationAuthenticateModule {}


### PR DESCRIPTION
added sequelize.authenticate method in connection factory

closes #235

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I realized that when sequelize module doens't sync models before initialization, if the connection fails no errors are thrown, starting application silently

Issue Number: #235 

## What is the new behavior?

Now before syncing, connection factory will try to authenticate to database running a simple query, if connection fails will throw a ConnectionRefusedError after all attempts


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information