### PR TITLE
feat: add url connections

### DIFF
--- a/lib/interfaces/sequelize-options.interface.ts
+++ b/lib/interfaces/sequelize-options.interface.ts
@@ -26,6 +26,10 @@ export type SequelizeModuleOptions = {
    * Default: true
    */
   synchronize?: boolean;
+  /**
+   * Another way to connect using a connection url
+   */
+  url?: string;
 } & Partial<SequelizeOptions>;
 
 export interface SequelizeOptionsFactory {

--- a/lib/sequelize-core.module.ts
+++ b/lib/sequelize-core.module.ts
@@ -119,9 +119,8 @@ export class SequelizeCoreModule implements OnApplicationShutdown {
     }
     // `as Type<SequelizeOptionsFactory>` is a workaround for microsoft/TypeScript#31603
     const inject = [
-      (options.useClass || options.useExisting) as Type<
-        SequelizeOptionsFactory
-      >,
+      (options.useClass ||
+        options.useExisting) as Type<SequelizeOptionsFactory>,
     ];
     return {
       provide: SEQUELIZE_MODULE_OPTIONS,
@@ -135,12 +134,18 @@ export class SequelizeCoreModule implements OnApplicationShutdown {
     options: SequelizeModuleOptions,
   ): Promise<Sequelize> {
     return await defer(async () => {
+      const { url, ...sequelizeOptions } = options;
+
       if (!options.autoLoadModels) {
-        return new Sequelize(options as SequelizeOptions);
+        return url
+          ? new Sequelize(url, sequelizeOptions as SequelizeOptions)
+          : new Sequelize(sequelizeOptions as SequelizeOptions);
       }
 
       const connectionToken = options.name || DEFAULT_CONNECTION_NAME;
-      const sequelize = new Sequelize(options);
+      const sequelize = url
+        ? new Sequelize(url, sequelizeOptions)
+        : new Sequelize(sequelizeOptions);
       const models = EntitiesMetadataStorage.getEntitiesByConnection(
         connectionToken,
       );

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -32,6 +32,15 @@ import { PhotoModule } from './photo/photo.module';
       retryAttempts: 2,
       retryDelay: 1000,
     }),
+    SequelizeModule.forRoot({
+      url: 'postgres://root:root@0.0.0.0:3306/test',
+      name: 'connection_3',
+      logging: false,
+      synchronize: true,
+      autoLoadModels: true,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    }),
   ],
 })
 export class ApplicationModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the module provides just a way to connect by knowing each part of the connection e.g. username, password and so on. But it isn't possible to pass a connection url as parameter to connect to the database.
By default sequelize supports this behavior

Issue Number: N/A


## What is the new behavior?
With this feature you can pass as an option an url to connect to the database.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information